### PR TITLE
Docker Composeによる開発/運用環境の分離と関連ドキュメントの更新

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -17,5 +17,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3 # Docker Buildx（新しいビルドツール）をセットアップ
 
-    - name: Build and run Docker containers
-      run: docker compose up --build
+    - name: Rename .env.template to .env
+      run: mv .env.template .env
+
+    - name: Build and run Docker containers in detached mode (production-like)
+      run: docker compose -f docker-compose.yml up --build -d
+
+    - name: Ensure containers are stopped and removed
+      if: always()
+      run: docker compose down
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # mcp-trello
+
+## Docker Composeの利用
+
+このプロジェクトでは、Dockerコンテナの起動と管理のために `docker-compose.yml` と `docker-compose.override.yml` を使用します。それぞれのファイルは以下の役割を持ちます。
+
+- `docker-compose.yml`: 運用環境でのアプリケーションの起動設定を定義します。これはアプリケーションのコアサービスと依存関係を含み、`tail -f /dev/null` などの開発用コマンドは含みません。
+- `docker-compose.override.yml`: 開発環境での追加設定を定義します。これには、ソースコードのボリュームマウントや、コンテナを継続的に稼働させるためのコマンド（例: `tail -f /dev/null`）などが含まれます。開発時に `docker compose up` を実行すると、このファイルが `docker-compose.yml` に自動的に適用されます。
+
+## 開発環境セットアップ
+
+このプロジェクトを開発環境でセットアップする手順は以下の通りです。
+
+### 1. Dockerコンテナの起動 (開発モード)
+開発モードでは、`docker-compose.override.yml` が自動的に読み込まれ、ホストのコード変更がコンテナに即座に反映されます。また、コンテナは継続的に稼働し続けます。
+
+以下のコマンドを実行して、Dockerコンテナをビルドして起動してください。
+
+```bash
+docker compose up --build -d
+```
+
+## 運用環境での起動
+
+運用環境では、`docker-compose.override.yml` を使用せず、`docker-compose.yml` のみを使用してFastMCPサーバーを起動します。このモードでは、アプリケーションのログが直接ターミナルに表示されます。
+
+```bash
+docker compose -f docker-compose.yml up --build
+```

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,5 @@
+services:
+  mcp-trello-server:
+    volumes:
+      - .:/app # 現在のディレクトリをコンテナの /app にマウント
+    command: tail -f /dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,4 @@ services:
   mcp-trello-server:
     build: .
     ports:
-      - "8000:8000" # FastMCPサーバーが使用するポートに合わせて調整が必要かもしれません
-    volumes:
-      - .:/app # 現在のディレクトリをコンテナの /app にマウント
+      - "8000:8000"


### PR DESCRIPTION
## 概要
Issue #9「Docker Composeを用いた開発/本番環境の起動挙動の明確化と分離」の解決のため、Docker Composeを用いて開発環境と運用環境の起動設定を明確に分離しました。これにより、各環境の役割と利用方法がより明確になります。

## 変更内容
- `docker-compose.yml` を運用環境の基準となる設定として整理し、運用時に必要な最小限のサービス定義にしました。
- `docker-compose.override.yml` を新規作成し、開発環境で必要なボリュームマウントやコンテナを起動し続けるためのコマンド（`tail -f /dev/null`）などを定義しました。
- `README.md` を更新し、Docker Composeの利用目的、`docker-compose.yml`と`docker-compose.override.yml`の役割、および各環境での具体的な起動手順を詳細に記載しました。
- `.github/workflows/docker-build-check.yml` を更新し、CIでのDockerビルドチェックが運用環境の設定で行われるよう修正しました。

## 動作確認
- 開発環境での起動: `docker compose up --build -d` を実行し、コンテナが起動し、ローカルのソースコード変更がコンテナに即座に反映されることを確認しました。
- 運用環境での起動: `docker compose -f docker-compose.yml up --build` を実行し、FastMCPサーバーが期待通りに起動し、アプリケーションが動作することを確認しました。
- CI/CDの動作: `.github/workflows/docker-build-check.yml` が意図通りに実行され、ビルドが成功することを確認しました。

## 関連Issue
#9

## 補足情報
なし