### PR TITLE
Trello APIクライアント機能の追加とテストの整備

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
 TRELLO_API_KEY=your_trello_api_key
-TRELLO_TOKEN=your_trello_token
+TRELLO_API_SECRET=your_trello_secret
+TRELLO_TOKEN=your_torello_token
 TRELLO_BOARD_ID=your_initial_board_id
-TRELLO_WORKSPACE_ID=your_initial_workspace_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-python-dotenv
-fastmcp
+python-dotenv==1.1.0
+fastmcp==2.7.1
+py-trello==0.20.1
+pytest==8.4.0

--- a/test_trello_client.py
+++ b/test_trello_client.py
@@ -1,0 +1,79 @@
+import pytest
+import os
+from trello import TrelloClient
+from trello_client import get_trello_client, get_board_by_id
+
+
+class TestGetTrelloClient:
+    def test_get_trello_client_success(self, monkeypatch):
+        """
+        環境変数が正しく設定されている場合にTrelloClientが正常に初期化されることをテストします。
+        """
+        monkeypatch.setenv("TRELLO_API_KEY", "test_key")
+        monkeypatch.setenv("TRELLO_API_SECRET", "test_secret")
+        monkeypatch.setenv("TRELLO_TOKEN", "test_token")
+
+        client = get_trello_client()
+        assert isinstance(client, TrelloClient)
+        assert client.api_key == "test_key"
+
+    def test_get_trello_client_no_api_key(self, monkeypatch):
+        """
+        TRELLO_API_KEYが設定されていない場合にValueErrorが発生することをテストします。
+        """
+        monkeypatch.delenv("TRELLO_API_KEY", raising=False)
+        monkeypatch.setenv("TRELLO_API_SECRET", "test_secret")
+        monkeypatch.setenv("TRELLO_TOKEN", "test_token")
+
+        with pytest.raises(ValueError, match="環境変数 'TRELLO_API_KEY' が設定されていません。"):
+            get_trello_client()
+
+    def test_get_trello_client_no_api_secret(self, monkeypatch):
+        """
+        TRELLO_API_SECRETが設定されていない場合にValueErrorが発生することをテストします。
+        """
+        monkeypatch.setenv("TRELLO_API_KEY", "test_key")
+        monkeypatch.delenv("TRELLO_API_SECRET", raising=False)
+        monkeypatch.setenv("TRELLO_TOKEN", "test_token")
+
+        with pytest.raises(ValueError, match="環境変数 'TRELLO_API_SECRET' が設定されていません。"):
+            get_trello_client()
+
+    def test_get_trello_client_no_token(self, monkeypatch):
+        """
+        TRELLO_TOKENが設定されていない場合にValueErrorが発生することをテストします。
+        """
+        monkeypatch.setenv("TRELLO_API_KEY", "test_key")
+        monkeypatch.setenv("TRELLO_API_SECRET", "test_secret")
+        monkeypatch.delenv("TRELLO_TOKEN", raising=False)
+
+        with pytest.raises(ValueError, match="環境変数 'TRELLO_TOKEN' が設定されていません。"):
+            get_trello_client()
+
+
+class TestGetBoardById:
+    def test_get_board_by_id_success(self, monkeypatch):
+        """
+        環境変数 TRELLO_BOARD_ID が正しく設定されている場合に特定のボードが取得できることをテストします。
+        """
+        monkeypatch.setenv("TRELLO_BOARD_ID", "test_board_id")
+        monkeypatch.setenv("TRELLO_API_KEY", "test_key")
+        monkeypatch.setenv("TRELLO_API_SECRET", "test_secret")
+        monkeypatch.setenv("TRELLO_TOKEN", "test_token")
+
+        mock_board = type("Board", (object,), {"id": "test_board_id", "name": "Test Board"})()
+        mock_client = type("TrelloClient", (object,), {"get_board": lambda *args, **kwargs: mock_board})()
+        monkeypatch.setattr("trello_client.get_trello_client", lambda: mock_client)
+
+        board = get_board_by_id()
+        assert board.id == "test_board_id"
+        assert board.name == "Test Board"
+
+    def test_get_board_by_id_no_env_var(self, monkeypatch):
+        """
+        TRELLO_BOARD_ID が設定されていない場合にValueErrorが発生することをテストします。
+        """
+        monkeypatch.delenv("TRELLO_BOARD_ID", raising=False)
+
+        with pytest.raises(ValueError, match="環境変数 'TRELLO_BOARD_ID' が設定されていません。"):
+            get_board_by_id()

--- a/trello_client.py
+++ b/trello_client.py
@@ -1,0 +1,57 @@
+import os
+from trello import TrelloClient
+
+def get_trello_client():
+    """
+    環境変数からTrello APIキーとトークンを読み込み、TrelloClientインスタンスを返します。
+    """
+    api_key = os.environ.get("TRELLO_API_KEY")
+    api_secret = os.environ.get("TRELLO_API_SECRET")
+    token = os.environ.get("TRELLO_TOKEN")
+
+    if not api_key:
+        raise ValueError("環境変数 'TRELLO_API_KEY' が設定されていません。")
+    if not api_secret:
+        raise ValueError("環境変数 'TRELLO_API_SECRET' が設定されていません。")
+    if not token:
+        raise ValueError("環境変数 'TRELLO_TOKEN' が設定されていません。")
+
+    client = TrelloClient(
+        api_key=api_key,
+        api_secret=api_secret,
+        token=token
+    )
+    return client
+
+def get_board_by_id():
+    """
+    環境変数 TRELLO_BOARD_ID で指定されたIDを持つTrelloボードを取得します。
+    """
+    board_id = os.environ.get("TRELLO_BOARD_ID")
+    if not board_id:
+        raise ValueError("環境変数 'TRELLO_BOARD_ID' が設定されていません。")
+
+    client = get_trello_client()
+    board = client.get_board(board_id)
+    return board
+
+if __name__ == "__main__":
+    # このスクリプトを直接実行した場合のテストコード
+    # 実際のAPIキーとトークンを設定してください（例: export TRELLO_API_KEY='your_key'）
+    try:
+        client = get_trello_client()
+        print("TrelloClientの初期化に成功しました。")
+
+        # すべてのボードを取得する例 (コメントアウト)
+        # boards = get_boards()
+        # for board in boards:
+        #     print(f"- {board.name} ({board.id})")
+
+        # 特定のボードをIDで取得する例
+        board = get_board_by_id()
+        print(f"取得したボード名: {board.name}, ID: {board.id}")
+
+    except ValueError as e:
+        print(f"エラー: {e}")
+    except Exception as e:
+        print(f"予期せぬエラーが発生しました: {e}")


### PR DESCRIPTION
## 概要
Trello APIとの通信を行うための統一クライアントを導入し、認証情報の安全な管理と特定のボード取得機能を追加します。

これにより、Trello APIを活用した今後の機能開発の基盤を確立します。

## 変更内容
主な変更点と追加・修正した内容は以下の通りです。

*   **`trello_client.py` の新規実装**:
    *   Trello APIキー (`TRELLO_API_KEY`)、APIシークレット (`TRELLO_API_SECRET`)、およびトークン (`TRELLO_TOKEN`) を環境変数から安全に読み込み、`TrelloClient` インスタンスを初期化する `get_trello_client` 関数を実装しました。
    *   環境変数 `TRELLO_BOARD_ID` で指定されたIDを持つ特定のTrelloボードを取得する `get_board_by_id` 関数を追加しました。

## 動作確認
*   `pytest` コマンドを実行し、すべての単体テストが正常にパスすることを確認しました。
*   実際に環境変数を設定し、`trello_client.py` を実行して、Trello APIから指定したボードが正常に取得できることを確認しました。
    ```bash
    export TRELLO_API_KEY="<あなたのTrello APIキー>"
    export TRELLO_API_SECRET="<あなたのTrello APIシークレット>"
    export TRELLO_TOKEN="<あなたのTrelloトークン>"
    export TRELLO_BOARD_ID="<取得したいボードのID>"
    python trello_client.py
    ```
    （上記コマンド実行後、指定したボード名とIDが表示されることを確認）

## 関連Issue
*   #11 (Trello APIクライアント導入に関する課題)

## 補足情報
*   実際のTrello APIとの通信には、有効なAPIキー、シークレット、トークン、ボードIDが必要です。これらはTrelloのDeveloperサイトで取得できます。
