### PR TITLE
Trello リスト処理を追加

### DIFF
--- a/test_trello_client.py
+++ b/test_trello_client.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 from trello import TrelloClient
-from trello_client import get_trello_client, get_board_by_id
+from trello_client import get_trello_client, get_board_by_id, get_lists_from_board, get_list_by_name_or_id, create_list_on_board
 
 
 class TestGetTrelloClient:
@@ -61,9 +61,15 @@ class TestGetBoardById:
         monkeypatch.setenv("TRELLO_API_SECRET", "test_secret")
         monkeypatch.setenv("TRELLO_TOKEN", "test_token")
 
-        mock_board = type("Board", (object,), {"id": "test_board_id", "name": "Test Board"})()
-        mock_client = type("TrelloClient", (object,), {"get_board": lambda *args, **kwargs: mock_board})()
-        monkeypatch.setattr("trello_client.get_trello_client", lambda: mock_client)
+        mock_board_obj = type("Board", (object,), {"id": "test_board_id", "name": "Test Board"})()
+
+        class MockTrelloClient:
+            def get_board(self, board_id):
+                if board_id == "test_board_id":
+                    return mock_board_obj
+                raise Exception('board not found')
+
+        monkeypatch.setattr("trello_client.get_trello_client", lambda: MockTrelloClient())
 
         board = get_board_by_id()
         assert board.id == "test_board_id"
@@ -77,3 +83,135 @@ class TestGetBoardById:
 
         with pytest.raises(ValueError, match="環境変数 'TRELLO_BOARD_ID' が設定されていません。"):
             get_board_by_id()
+
+    def test_get_lists_from_board_success(self, monkeypatch):
+        """
+        指定されたボードからリストが正しく取得できることをテストします。
+        """
+        # モックのListインスタンスを作成
+        mock_list_1 = type("List", (object,), {"id": "list1_id", "name": "To Do"})()
+        mock_list_2 = type("List", (object,), {"id": "list2_id", "name": "Done"})()
+        mock_lists = [mock_list_1, mock_list_2]
+
+        # モックのBoardインスタンスとそのlist_listsメソッドを作成
+        mock_board = type("Board", (object,), {"list_lists": lambda *args, **kwargs: mock_lists})()
+
+        # get_lists_from_board関数を呼び出し
+        lists = get_lists_from_board(mock_board)
+
+        # 結果を検証
+        assert len(lists) == 2
+        assert lists[0].name == "To Do"
+        assert lists[0].id == "list1_id"
+        assert lists[1].name == "Done"
+        assert lists[1].id == "list2_id"
+
+    def test_get_lists_from_board_no_board(self):
+        """
+        ボードオブジェクトが指定されていない場合にValueErrorが発生することをテストします。
+        """
+        with pytest.raises(ValueError, match="ボードオブジェクトが指定されていません。"):
+            get_lists_from_board(None)
+
+
+class TestGetListByNameOrId:
+    def test_get_list_by_id_success(self, monkeypatch):
+        """
+        IDでリストが正しく取得できることをテストします。
+        """
+        mock_list = type("List", (object,), {"id": "test_list_id", "name": "Test List"})()
+        class MockBoardGetList:
+            def get_list(self, list_id):
+                if list_id == "test_list_id":
+                    return mock_list
+                raise Exception('list not found')
+        mock_board = MockBoardGetList()
+
+        list_obj = get_list_by_name_or_id(mock_board, "test_list_id")
+        assert list_obj.id == "test_list_id"
+        assert list_obj.name == "Test List"
+
+    def test_get_list_by_name_success(self, monkeypatch):
+        """
+        名前でリストが正しく取得できることをテストします。
+        """
+        mock_list_1 = type("List", (object,), {"id": "list1_id", "name": "List One"})()
+        mock_list_2 = type("List", (object,), {"id": "list2_id", "name": "Test List Name"})()
+        mock_lists = [mock_list_1, mock_list_2]
+
+        class MockBoardListLists:
+            def get_list(self, list_id):
+                raise Exception('list not found')
+            def list_lists(self, *args, **kwargs):
+                return mock_lists
+        mock_board = MockBoardListLists()
+
+        list_obj = get_list_by_name_or_id(mock_board, "Test List Name")
+        assert list_obj.id == "list2_id"
+        assert list_obj.name == "Test List Name"
+
+    def test_get_list_by_name_or_id_not_found(self, monkeypatch):
+        """
+        指定されたIDまたは名前のリストが見つからない場合にValueErrorが発生することをテストします。
+        """
+        mock_list_1 = type("List", (object,), {"id": "list1_id", "name": "List One"})()
+        mock_lists = [mock_list_1]
+
+        class MockBoardNotFound:
+            def get_list(self, list_id):
+                raise Exception('list not found')
+            def list_lists(self, *args, **kwargs):
+                return mock_lists
+        mock_board = MockBoardNotFound()
+
+        with pytest.raises(ValueError, match="指定されたIDまたは名前 'NonExistent' のリストはボードに存在しません。"):
+            get_list_by_name_or_id(mock_board, "NonExistent")
+
+    def test_get_list_by_name_or_id_no_board(self):
+        """
+        ボードオブジェクトが指定されていない場合にValueErrorが発生することをテストします。
+        """
+        with pytest.raises(ValueError, match="ボードオブジェクトが指定されていません。"):
+            get_list_by_name_or_id(None, "some_id_or_name")
+
+    def test_get_list_by_name_or_id_no_identifier(self, monkeypatch):
+        """
+        リストのIDまたは名前が指定されていない場合にValueErrorが発生することをテストします。
+        """
+        mock_board = type("Board", (object,), {})()
+        with pytest.raises(ValueError, match="リストのIDまたは名前が指定されていません。"):
+            get_list_by_name_or_id(mock_board, None)
+
+
+class TestCreateListOnBoard:
+    def test_create_list_on_board_success(self, monkeypatch):
+        """
+        Trelloボードに新しいリストが正常に作成されることをテストします。
+        """
+        mock_new_list = type("List", (object,), {"id": "new_list_id", "name": "New Test List"})()
+
+        class MockBoardAddList:
+            def add_list(self, list_name):
+                if list_name == "New Test List":
+                    return mock_new_list
+                return None
+        mock_board = MockBoardAddList()
+
+        new_list = create_list_on_board(mock_board, "New Test List")
+        assert new_list.id == "new_list_id"
+        assert new_list.name == "New Test List"
+
+    def test_create_list_on_board_no_board(self):
+        """
+        ボードオブジェクトが指定されていない場合にValueErrorが発生することをテストします。
+        """
+        with pytest.raises(ValueError, match="ボードオブジェクトが指定されていません。"):
+            create_list_on_board(None, "New List")
+
+    def test_create_list_on_board_no_list_name(self, monkeypatch):
+        """
+        リスト名が指定されていない場合にValueErrorが発生することをテストします。
+        """
+        mock_board = type("Board", (object,), {})()
+        with pytest.raises(ValueError, match="リスト名が指定されていません。"):
+            create_list_on_board(mock_board, None)

--- a/trello_client.py
+++ b/trello_client.py
@@ -35,17 +35,56 @@ def get_board_by_id():
     board = client.get_board(board_id)
     return board
 
+def get_lists_from_board(board):
+    """
+    指定されたTrelloボード内のすべてのリストを取得します。
+    """
+    if not board:
+        raise ValueError("ボードオブジェクトが指定されていません。")
+    lists = board.list_lists()
+    return lists
+
+def get_list_by_name_or_id(board, list_identifier):
+    """
+    指定されたTrelloボードから、IDまたは名前で特定のリストを取得します。
+    """
+    if not board:
+        raise ValueError("ボードオブジェクトが指定されていません。")
+    if not list_identifier:
+        raise ValueError("リストのIDまたは名前が指定されていません。")
+
+    # まずはIDで取得を試みる
+    try:
+        list_obj = board.get_list(list_identifier)
+        return list_obj
+    except Exception:
+        pass # IDでの取得に失敗した場合は、名前で検索を試みる
+
+    # 名前で検索
+    for list_obj in board.list_lists():
+        if list_obj.name == list_identifier:
+            return list_obj
+
+    raise ValueError(f"指定されたIDまたは名前 '{list_identifier}' のリストはボードに存在しません。")
+
+def create_list_on_board(board, list_name):
+    """
+    指定されたTrelloボードに新しいリストを作成します。
+    """
+    if not board:
+        raise ValueError("ボードオブジェクトが指定されていません。")
+    if not list_name:
+        raise ValueError("リスト名が指定されていません。")
+
+    new_list = board.add_list(list_name)
+    return new_list
+
 if __name__ == "__main__":
     # このスクリプトを直接実行した場合のテストコード
     # 実際のAPIキーとトークンを設定してください（例: export TRELLO_API_KEY='your_key'）
     try:
         client = get_trello_client()
         print("TrelloClientの初期化に成功しました。")
-
-        # すべてのボードを取得する例 (コメントアウト)
-        # boards = get_boards()
-        # for board in boards:
-        #     print(f"- {board.name} ({board.id})")
 
         # 特定のボードをIDで取得する例
         board = get_board_by_id()


### PR DESCRIPTION
## 概要
Trelloボード内のリストを操作するための機能（取得、作成）を追加します。これにより、ボード内のリストの管理と自動化が可能になります。

## 変更内容
主な変更点と追加・修正した内容は以下の通りです。

*   **`trello_client.py` の機能追加**:
    *   指定されたTrelloボード内のすべてのリストを取得する `get_lists_from_board` 関数を追加しました。
    *   指定されたTrelloボードからIDまたは名前で特定のリストを取得する `get_list_by_name_or_id` 関数を追加しました。
    *   指定されたTrelloボードに新しいリストを作成する `create_list_on_board` 関数を追加しました。
*   **`test_trello_client.py` のテストコード追加・修正**

## 動作確認
*   `pytest` コマンドを実行し、追加されたすべての単体テストが正常にパスすることを確認しました。
    ```bash
    pytest
    ```

## 関連Issue
*   #13  (Trello リストの作成、取得に関する機能追加)
